### PR TITLE
Add ability to register process wrapper functions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def process_graph_path(request) -> Path:
 
 @pytest.fixture
 def process_registry() -> ProcessRegistry:
-    registry = ProcessRegistry()
+    registry = ProcessRegistry(wrap_funcs=[])
 
     _max = lambda data, dimension=None, ignore_nodata=True, **kwargs: data.max(
         dim=dimension, skipna=ignore_nodata, keep_attrs=True


### PR DESCRIPTION
This allows us to put the `@process` decorator with the processes. This belongs there, because the changes in https://github.com/Open-EO/openeo-processes-dask/pull/29 require quite specific changes to it that are then tightly coupled to the process implementations.