### PR TITLE
Make datetime subtypes return numpy datetime objects

### DIFF
--- a/openeo_pg_parser_networkx/pg_schema.py
+++ b/openeo_pg_parser_networkx/pg_schema.py
@@ -148,7 +148,7 @@ class BoundingBox(BaseModel, arbitrary_types_allowed=True):
 
 
 class Date(BaseModel):
-    __root__: pendulum.Date
+    __root__: datetime.datetime
 
     @validator("__root__", pre=True)
     def validate_time(cls, value: Any) -> Any:
@@ -157,7 +157,7 @@ class Date(BaseModel):
             and len(value) <= 11
             and match(r"[0-9]{4}[-/][0-9]{2}[-/][0-9]{2}T?", value)
         ):
-            return pendulum.parse(value).date()
+            return pendulum.parse(value)
         raise ValidationError("Could not parse `Date` from input.")
 
     def to_numpy(self):

--- a/openeo_pg_parser_networkx/pg_schema.py
+++ b/openeo_pg_parser_networkx/pg_schema.py
@@ -188,11 +188,31 @@ class Time(BaseModel):
 
 
 class TemporalInterval(BaseModel):
-    __root__: list[Union[Year, Date, DateTime, Time]]
+    __root__: list[Union[Year, Date, DateTime, Time]] = Field(min_length=2, max_length=2)
+
+    @property
+    def start(self):
+        return self.__root__[0]
+
+    @property
+    def end(self):
+        return self.__root__[1]
+
+    def __iter__(self):
+        return iter(self.__root__)
+
+    def __getitem__(self, item):
+        return self.__root__[item]
 
 
 class TemporalIntervals(BaseModel):
     __root__: list[TemporalInterval]
+
+    def __iter__(self):
+        return iter(self.__root__)
+
+    def __getitem__(self, item) -> TemporalInterval:
+        return self.__root__[item]
 
 
 ResultReference.update_forward_refs()

--- a/openeo_pg_parser_networkx/pg_schema.py
+++ b/openeo_pg_parser_networkx/pg_schema.py
@@ -166,13 +166,6 @@ class Duration(BaseModel):
     __root__: str = Field(regex=r"P[0-9]*Y?[0-9]*M?[0-9]*D?T?[0-9]*H?[0-9]*M?[0-9]*S?")
 
 
-class Features(BaseModel):
-    id: Optional[str]
-    type: str
-    geometry: dict
-    properties: Optional[dict]
-
-
 GeoJson = Union[FeatureCollection, Feature, GeometryCollection, MultiPolygon, Polygon]
 # The GeoJson spec (https://www.rfc-editor.org/rfc/rfc7946.html#ref-GJ2008) doesn't
 # have a crs field anymore and recommends assuming it to be EPSG:4326, so we do the same.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ networkx = {extras = ["default"], version = "^2.8.6"}
 shapely = "^1.8.4"
 geojson-pydantic = "^0.5.0"
 numpy = "^1.24.1"
+pendulum = "^2.1.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ pyproj = "^3.4.0"
 networkx = {extras = ["default"], version = "^2.8.6"}
 shapely = "^1.8.4"
 geojson-pydantic = "^0.5.0"
+numpy = "^1.24.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.3"

--- a/tests/test_pg_parser.py
+++ b/tests/test_pg_parser.py
@@ -1,9 +1,11 @@
 import datetime
 import json
 
+import numpy as np
 import pendulum
 import pyproj
 import pytest
+from pydantic import ValidationError
 
 from openeo_pg_parser_networkx import OpenEOProcessGraph
 from openeo_pg_parser_networkx.pg_schema import *
@@ -173,28 +175,32 @@ def test_output_format(get_process_graph_with_args):
         assert not isinstance(parsed_arg, OutputFormat)
 
 
-def test_temporal_interval(get_process_graph_with_args):
-    argument1 = {'temporal_interval': ['1990-01-01T12:00:00', '20:00:00']}
+def test_temporal_intervals(get_process_graph_with_args):
+    argument1 = {
+        'temporal_intervals': [
+            ['1990-01-01T12:00:00', '20:00:00'],
+            ['1995-01-30', '2000'],
+            ['1995-01-30', '2000'],
+        ]
+    }
     pg = get_process_graph_with_args(argument1)
-    parsed_arg = (
+    parsed_intervals = (
         ProcessGraph.parse_obj(pg)
         .process_graph[TEST_NODE_KEY]
-        .arguments["temporal_interval"]
+        .arguments["temporal_intervals"]
     )
-    assert isinstance(parsed_arg, TemporalInterval)
-    assert isinstance(parsed_arg.start, DateTime)
-    assert isinstance(parsed_arg.end, Time)
+    assert isinstance(parsed_intervals, TemporalIntervals)
 
-    argument2 = {'temporal_interval': ['1990-01-01T12:00:00', '20:00:00']}
-    pg = get_process_graph_with_args(argument2)
-    parsed_arg = (
-        ProcessGraph.parse_obj(pg)
-        .process_graph[TEST_NODE_KEY]
-        .arguments["temporal_interval"]
-    )
-    assert isinstance(parsed_arg, TemporalInterval)
-    assert isinstance(parsed_arg.start, DateTime)
-    assert isinstance(parsed_arg.end, Time)
+    first_interval = parsed_intervals[0]
+    second_interval = parsed_intervals[1]
+
+    assert isinstance(first_interval, TemporalInterval)
+    assert isinstance(first_interval.start, DateTime)
+    assert isinstance(first_interval.end, Time)
+
+    assert isinstance(second_interval, TemporalInterval)
+    assert isinstance(second_interval.start, Date)
+    assert isinstance(second_interval.end, Year)
 
 
 def test_duration(get_process_graph_with_args):
@@ -205,12 +211,63 @@ def test_duration(get_process_graph_with_args):
     )
     assert isinstance(parsed_arg, Duration)
     assert isinstance(parsed_arg.__root__, pendulum.Duration)
+    with pytest.raises(NotImplementedError):
+        parsed_arg.to_numpy()
 
 
-def test_date(get_process_graph_with_args):
-    argument = {'datetime': '1975-05-21T22:00:00'}
-    pg = get_process_graph_with_args(argument)
+def test_datetime(get_process_graph_with_args):
+    argument_valid = {'datetime': '1975-05-21T22:00:00'}
+    pg = get_process_graph_with_args(argument_valid)
     parsed_arg = (
         ProcessGraph.parse_obj(pg).process_graph[TEST_NODE_KEY].arguments["datetime"]
     )
+    assert isinstance(parsed_arg, DateTime)
     assert isinstance(parsed_arg.__root__, datetime.datetime)
+    assert parsed_arg.to_numpy() == np.datetime64(argument_valid["datetime"])
+
+    with pytest.raises(ValidationError):
+        DateTime.parse_obj('21-05-1975T22:00:00')
+
+
+def test_date(get_process_graph_with_args):
+    argument_valid = {'date': '1975-05-21'}
+    pg = get_process_graph_with_args(argument_valid)
+    parsed_arg = ProcessGraph.parse_obj(pg).process_graph[TEST_NODE_KEY].arguments["date"]
+    assert isinstance(parsed_arg, Date)
+    assert isinstance(parsed_arg.__root__, pendulum.Date)
+
+    with pytest.raises(NotImplementedError):
+        parsed_arg.to_numpy()
+
+    with pytest.raises(ValidationError):
+        DateTime.parse_obj('21-05-1975')
+        DateTime.parse_obj('22:00:80')
+
+
+def test_year(get_process_graph_with_args):
+    argument_valid = {'year': '1975'}
+    pg = get_process_graph_with_args(argument_valid)
+    parsed_arg = ProcessGraph.parse_obj(pg).process_graph[TEST_NODE_KEY].arguments["year"]
+    assert isinstance(parsed_arg, Year)
+    assert isinstance(parsed_arg.__root__, datetime.datetime)
+    assert parsed_arg.to_numpy() == np.datetime64(argument_valid["year"])
+
+    with pytest.raises(ValidationError):
+        DateTime.parse_obj('75')
+        DateTime.parse_obj('0001')
+        DateTime.parse_obj('22:00:80')
+
+
+def test_time(get_process_graph_with_args):
+    argument_valid = {'time': '22:00:00'}
+    pg = get_process_graph_with_args(argument_valid)
+    parsed_arg = ProcessGraph.parse_obj(pg).process_graph[TEST_NODE_KEY].arguments["time"]
+    assert isinstance(parsed_arg, Time)
+    assert isinstance(parsed_arg.__root__, pendulum.Time)
+
+    with pytest.raises(NotImplementedError):
+        parsed_arg.to_numpy()
+
+    with pytest.raises(ValidationError):
+        DateTime.parse_obj('22:00:80')
+        DateTime.parse_obj('0001')

--- a/tests/test_pg_parser.py
+++ b/tests/test_pg_parser.py
@@ -234,7 +234,7 @@ def test_date(get_process_graph_with_args):
     pg = get_process_graph_with_args(argument_valid)
     parsed_arg = ProcessGraph.parse_obj(pg).process_graph[TEST_NODE_KEY].arguments["date"]
     assert isinstance(parsed_arg, Date)
-    assert isinstance(parsed_arg.__root__, pendulum.Date)
+    assert isinstance(parsed_arg.__root__, datetime.datetime)
 
     with pytest.raises(NotImplementedError):
         parsed_arg.to_numpy()

--- a/tests/test_pg_parser.py
+++ b/tests/test_pg_parser.py
@@ -1,5 +1,7 @@
+import datetime
 import json
 
+import pendulum
 import pyproj
 import pytest
 
@@ -180,8 +182,8 @@ def test_temporal_interval(get_process_graph_with_args):
         .arguments["temporal_interval"]
     )
     assert isinstance(parsed_arg, TemporalInterval)
-    assert isinstance(parsed_arg.__root__[0], DateTime)
-    assert isinstance(parsed_arg.__root__[1], Time)
+    assert isinstance(parsed_arg.start, DateTime)
+    assert isinstance(parsed_arg.end, Time)
 
     argument2 = {'temporal_interval': ['1990-01-01T12:00:00', '20:00:00']}
     pg = get_process_graph_with_args(argument2)
@@ -191,8 +193,8 @@ def test_temporal_interval(get_process_graph_with_args):
         .arguments["temporal_interval"]
     )
     assert isinstance(parsed_arg, TemporalInterval)
-    assert isinstance(parsed_arg.__root__[0], DateTime)
-    assert isinstance(parsed_arg.__root__[1], Time)
+    assert isinstance(parsed_arg.start, DateTime)
+    assert isinstance(parsed_arg.end, Time)
 
 
 def test_duration(get_process_graph_with_args):
@@ -202,3 +204,13 @@ def test_duration(get_process_graph_with_args):
         ProcessGraph.parse_obj(pg).process_graph[TEST_NODE_KEY].arguments["duration"]
     )
     assert isinstance(parsed_arg, Duration)
+    assert isinstance(parsed_arg.__root__, pendulum.Duration)
+
+
+def test_date(get_process_graph_with_args):
+    argument = {'datetime': '1975-05-21T22:00:00'}
+    pg = get_process_graph_with_args(argument)
+    parsed_arg = (
+        ProcessGraph.parse_obj(pg).process_graph[TEST_NODE_KEY].arguments["datetime"]
+    )
+    assert isinstance(parsed_arg.__root__, datetime.datetime)


### PR DESCRIPTION
Closes https://eodc.atlassian.net/browse/EODCAPI-168

Couple of improvements:
- Extended the pydantic model such that input is validated against the provided regexes 
- temporal types now use the pendulum library for parsing, because this handles the required cases out of the box
- the unambiguous temporal type DateTime (points to a single instance in time) is stored as a python datetime object
- the semi-ambiguous Year and Date types are also stored as python datetime objects and point to YYYY-01-01:00:00:00 and YYYY-MM-DD:00:00:00 respectively
- The ambiguous type Time, which doesn't point to a unique point in time is stored as a pendulum.Time object and needs to be further specified, before it can be cast to a numpy datetime value.

Let me know what you think!