### PR TITLE
feat: add to_numpy() for Date and support open intervals

### DIFF
--- a/openeo_pg_parser_networkx/pg_schema.py
+++ b/openeo_pg_parser_networkx/pg_schema.py
@@ -241,7 +241,7 @@ class Duration(BaseModel):
 
 
 class TemporalInterval(BaseModel):
-    __root__: list[Union[Year, Date, DateTime, Time]]
+    __root__: list[Union[Year, Date, DateTime, Time, None]]
 
     @property
     def start(self):

--- a/openeo_pg_parser_networkx/pg_schema.py
+++ b/openeo_pg_parser_networkx/pg_schema.py
@@ -161,7 +161,7 @@ class Date(BaseModel):
         raise ValidationError("Could not parse `Date` from input.")
 
     def to_numpy(self):
-        raise NotImplementedError
+        return np.datetime64(self.__root__)
 
     def __repr__(self):
         return self.__root__.__repr__()

--- a/tests/test_pg_parser.py
+++ b/tests/test_pg_parser.py
@@ -246,6 +246,7 @@ def test_date(get_process_graph_with_args):
     parsed_arg = ProcessGraph.parse_obj(pg).process_graph[TEST_NODE_KEY].arguments["date"]
     assert isinstance(parsed_arg, Date)
     assert isinstance(parsed_arg.__root__, datetime.datetime)
+    assert parsed_arg.to_numpy() == np.datetime64(argument_valid["date"])
 
     with pytest.raises(ValidationError):
         DateTime.parse_obj('21-05-1975')

--- a/tests/test_pg_parser.py
+++ b/tests/test_pg_parser.py
@@ -191,7 +191,7 @@ def test_temporal_intervals(get_process_graph_with_args):
         'temporal_intervals': [
             ['1990-01-01T12:00:00', '20:00:00'],
             ['1995-01-30', '2000'],
-            ['1995-01-30', '2000'],
+            ['1995-01-30', None],
         ]
     }
     pg = get_process_graph_with_args(argument1)
@@ -204,6 +204,7 @@ def test_temporal_intervals(get_process_graph_with_args):
 
     first_interval = parsed_intervals[0]
     second_interval = parsed_intervals[1]
+    third_interval = parsed_intervals[2]
 
     assert isinstance(first_interval, TemporalInterval)
     assert isinstance(first_interval.start, DateTime)
@@ -212,6 +213,9 @@ def test_temporal_intervals(get_process_graph_with_args):
     assert isinstance(second_interval, TemporalInterval)
     assert isinstance(second_interval.start, Date)
     assert isinstance(second_interval.end, Year)
+    
+    assert isinstance(third_interval, TemporalInterval)
+    assert isinstance(second_interval.start, Date)
 
 
 def test_duration(get_process_graph_with_args):

--- a/tests/test_pg_parser.py
+++ b/tests/test_pg_parser.py
@@ -247,9 +247,6 @@ def test_date(get_process_graph_with_args):
     assert isinstance(parsed_arg, Date)
     assert isinstance(parsed_arg.__root__, datetime.datetime)
 
-    with pytest.raises(NotImplementedError):
-        parsed_arg.to_numpy()
-
     with pytest.raises(ValidationError):
         DateTime.parse_obj('21-05-1975')
         DateTime.parse_obj('22:00:80')

--- a/tests/test_pg_parser.py
+++ b/tests/test_pg_parser.py
@@ -213,7 +213,7 @@ def test_temporal_intervals(get_process_graph_with_args):
     assert isinstance(second_interval, TemporalInterval)
     assert isinstance(second_interval.start, Date)
     assert isinstance(second_interval.end, Year)
-    
+
     assert isinstance(third_interval, TemporalInterval)
     assert isinstance(second_interval.start, Date)
 


### PR DESCRIPTION
Added method `to_numpy()` for class `Date`, since the base class `datetime.datetime` is the same as for `DateTime`, where `to_numpy()` was already implemented.

Added the possibility to have a `None` value in a `TemporalInterval`, which allows for open ended intervals.