### PR TITLE
feat: add validator for temporal interval

### DIFF
--- a/tests/test_pg_parser.py
+++ b/tests/test_pg_parser.py
@@ -232,6 +232,10 @@ def test_invalid_temporal_intervals():
     with pytest.raises(ValidationError):
         TemporalInterval.parse_obj([None, None])
     with pytest.raises(ValidationError):
+        TemporalInterval.parse_obj(['15:00:00', '1990-01-01T20:00:00', '11:00:00'])
+    with pytest.raises(ValidationError):
+        TemporalInterval.parse_obj(['1990-01-01T20:00:00'])
+    with pytest.raises(ValidationError):
         TemporalInterval.parse_obj([None, '13:00:00'])
     with pytest.raises(ValidationError):
         TemporalInterval.parse_obj(['13:00:00', None])

--- a/tests/test_pg_parser.py
+++ b/tests/test_pg_parser.py
@@ -208,14 +208,15 @@ def test_temporal_intervals(get_process_graph_with_args):
 
     assert isinstance(first_interval, TemporalInterval)
     assert isinstance(first_interval.start, DateTime)
-    assert isinstance(first_interval.end, Time)
+    assert isinstance(first_interval.end, DateTime)
 
     assert isinstance(second_interval, TemporalInterval)
     assert isinstance(second_interval.start, Date)
     assert isinstance(second_interval.end, Year)
 
     assert isinstance(third_interval, TemporalInterval)
-    assert isinstance(second_interval.start, Date)
+    assert isinstance(third_interval.start, Date)
+    assert third_interval.end is None
 
 
 def test_duration(get_process_graph_with_args):

--- a/tests/test_pg_parser.py
+++ b/tests/test_pg_parser.py
@@ -209,6 +209,7 @@ def test_temporal_intervals(get_process_graph_with_args):
     assert isinstance(first_interval, TemporalInterval)
     assert isinstance(first_interval.start, DateTime)
     assert isinstance(first_interval.end, DateTime)
+    assert first_interval.end.__root__ == first_interval.start.__root__.add(hours=8)
 
     assert isinstance(second_interval, TemporalInterval)
     assert isinstance(second_interval.start, Date)

--- a/tests/test_pg_parser.py
+++ b/tests/test_pg_parser.py
@@ -192,6 +192,7 @@ def test_temporal_intervals(get_process_graph_with_args):
             ['1990-01-01T12:00:00', '20:00:00'],
             ['1995-01-30', '2000'],
             ['1995-01-30', None],
+            ['15:00:00', '1990-01-01T20:00:00'],
         ]
     }
     pg = get_process_graph_with_args(argument1)
@@ -205,6 +206,7 @@ def test_temporal_intervals(get_process_graph_with_args):
     first_interval = parsed_intervals[0]
     second_interval = parsed_intervals[1]
     third_interval = parsed_intervals[2]
+    fourth_interval = parsed_intervals[3]
 
     assert isinstance(first_interval, TemporalInterval)
     assert isinstance(first_interval.start, DateTime)
@@ -218,6 +220,23 @@ def test_temporal_intervals(get_process_graph_with_args):
     assert isinstance(third_interval, TemporalInterval)
     assert isinstance(third_interval.start, Date)
     assert third_interval.end is None
+
+    assert isinstance(fourth_interval, TemporalInterval)
+    assert isinstance(fourth_interval.start, DateTime)
+    assert isinstance(fourth_interval.end, DateTime)
+
+
+def test_invalid_temporal_intervals():
+    with pytest.raises(ValidationError):
+        TemporalInterval.parse_obj(['1990-01-01T12:00:00', '11:00:00'])
+    with pytest.raises(ValidationError):
+        TemporalInterval.parse_obj([None, None])
+    with pytest.raises(ValidationError):
+        TemporalInterval.parse_obj([None, '13:00:00'])
+    with pytest.raises(ValidationError):
+        TemporalInterval.parse_obj(['13:00:00', None])
+    with pytest.raises(ValidationError):
+        TemporalInterval.parse_obj(['13:00:00', '14:00:00'])
 
 
 def test_duration(get_process_graph_with_args):


### PR DESCRIPTION
This is to resolve what's mentioned [here](https://github.com/Open-EO/openeo-processes-dask/pull/76#discussion_r1123298317): `Time` should automatically resolve to a usable datetime or fail validation.