### PR TITLE
chore: allow numpy ^1.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ pyproj = "^3.4.0"
 networkx = "^2.8.6"
 shapely = ">=1.8"
 geojson-pydantic = "^0.5.0"
-numpy = "1.22.0"
+numpy = "^1.20.3"
 pendulum = "^2.1.2"
 matplotlib = { version = "^3.7.1", optional = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ pyproj = "^3.4.0"
 networkx = "^2.8.6"
 shapely = ">=1.8"
 geojson-pydantic = "^0.5.0"
-numpy = "^1.24.1"
+numpy = "1.22.0"
 pendulum = "^2.1.2"
 matplotlib = { version = "^3.7.1", optional = true }
 


### PR DESCRIPTION
This was messing with me upstream, since tests pass, might as well relax this requirement.