### PR TITLE
chore: auto sync __version__ with pyproject.toml

### DIFF
--- a/openeo_pg_parser_networkx/__init__.py
+++ b/openeo_pg_parser_networkx/__init__.py
@@ -1,4 +1,6 @@
-__version__ = "2023.5.1"
+import importlib.metadata
+
+__version__ = importlib.metadata.version('openeo_pg_parser_networkx')
 
 from openeo_pg_parser_networkx.graph import OpenEOProcessGraph
 from openeo_pg_parser_networkx.process_registry import Process, ProcessRegistry


### PR DESCRIPTION
This could get out of sync, so just set this dynamically instead