### PR TITLE
refactor: remove OutputFormat pydantic model

### DIFF
--- a/openeo_pg_parser_networkx/pg_schema.py
+++ b/openeo_pg_parser_networkx/pg_schema.py
@@ -51,7 +51,6 @@ __all__ = [
     "TemporalIntervals",
     "GeoJson",
     "JobId",
-    "OutputFormat",
     "DEFAULT_CRS",
 ]
 
@@ -79,7 +78,6 @@ class ProcessNode(BaseModel, arbitrary_types_allowed=True):
                 ProcessGraph,
                 BoundingBox,
                 JobId,
-                OutputFormat,
                 Year,
                 Date,
                 DateTime,
@@ -343,10 +341,6 @@ class JobId(BaseModel):
     __root__: str = Field(
         regex=r"(eodc-jb-|jb-)[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
     )
-
-
-class OutputFormat(BaseModel):
-    __root__: str = Field(regex=r"(?i)(gtiff|geotiff|netcdf|json)")
 
 
 ResultReference.update_forward_refs()

--- a/tests/test_pg_parser.py
+++ b/tests/test_pg_parser.py
@@ -154,41 +154,6 @@ def test_jobid(get_process_graph_with_args):
     assert isinstance(parsed_arg, JobId)
 
 
-def test_output_format(get_process_graph_with_args):
-    #         regex=r"(gtiff|GTiff|geotiff|GeoTiff|Netcdf|NetCDF|netcdf|json)"
-
-    valid_file_formats = [
-        "gtiff",
-        "GTiff",
-        "netCDF",
-        "Netcdf",
-        "netcdf",
-        "json",
-        "geotiff",
-        "GeoTiff",
-    ]
-    arguments = [{'output_format': v} for v in valid_file_formats]
-    for argument in arguments:
-        pg = get_process_graph_with_args(argument)
-        parsed_arg = (
-            ProcessGraph.parse_obj(pg)
-            .process_graph[TEST_NODE_KEY]
-            .arguments["output_format"]
-        )
-        assert isinstance(parsed_arg, OutputFormat)
-
-    invalid_file_formats = ["yo", "pdf"]
-    arguments = [{'output_format': v} for v in invalid_file_formats]
-    for argument in arguments:
-        pg = get_process_graph_with_args(argument)
-        parsed_arg = (
-            ProcessGraph.parse_obj(pg)
-            .process_graph[TEST_NODE_KEY]
-            .arguments["output_format"]
-        )
-        assert not isinstance(parsed_arg, OutputFormat)
-
-
 def test_temporal_intervals(get_process_graph_with_args):
     argument1 = {
         'temporal_intervals': [


### PR DESCRIPTION
This model isn't actually very useful, I'd rather treat these format strings as raw strings, so will delete this.