### PR TITLE
Change log level to debug

### DIFF
--- a/openeo_pg_parser_networkx/graph.py
+++ b/openeo_pg_parser_networkx/graph.py
@@ -100,7 +100,7 @@ class OpenEOProcessGraph:
                 "root": ProcessGraphUnflattener.unflatten(raw_flat_graph["process_graph"])
             }
         }
-        logger.info("Deserialised process graph into nested structure")
+        logger.debug("Deserialised process graph into nested structure")
         return nested_graph
 
     @staticmethod
@@ -221,7 +221,7 @@ class OpenEOProcessGraph:
         """
         Parse all the required information from the current node into self.G and recursively walk child nodes.
         """
-        logger.info(f"Walking node {self._EVAL_ENV.node_uid}")
+        logger.debug(f"Walking node {self._EVAL_ENV.node_uid}")
 
         self.G.add_node(
             self._EVAL_ENV.node_uid,


### PR DESCRIPTION
Logging the messages with level INFO creates a considerably amount of text when executing a large process graph.
I propose to set the log level to debug to avoid this.

![image](https://github.com/Open-EO/openeo-pg-parser-networkx/assets/31700619/45ed1408-ae87-47d5-acb6-3b205b5d0360)
