### PR TITLE
fix: aggregated data being incorrectly calculated because of results_cache

### DIFF
--- a/openeo_pg_parser_networkx/graph.py
+++ b/openeo_pg_parser_networkx/graph.py
@@ -357,6 +357,24 @@ class OpenEOProcessGraph:
 
             try:
                 # If this node has already been computed once, just grab that result from the results_cache instead of recomputing it.
+                # This cannot be done for aggregated data as the wrapped function has to be called multiple times with different values.
+                # This also means the results_cache will be useless for these functions.
+                # TODO: track how often functions need to be called and check if they have been called that many times, if yes, we can
+                # use the cache for aggregate functions, but this is probably not super necessary
+                parent_node_id = [edge[0] for edge in self.edges if edge[1] == node]
+
+                if parent_node_id:
+                    parent_node_process_id = [
+                        n[1]["process_id"]
+                        for n in self.nodes
+                        if n[0] == parent_node_id[0]
+                    ]
+
+                    if parent_node_process_id and parent_node_process_id[0] in [
+                        "aggregate_temporal_period"
+                    ]:
+                        raise KeyError()
+
                 return results_cache.__getitem__(node)
             except KeyError:
                 for _, source_node, data in self.G.out_edges(node, data=True):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openeo-pg-parser-networkx"
-version = "2023.8.0"
+version = "2023.8.1"
 
 description = "Parse OpenEO process graphs from JSON to traversible Python objects."
 authors = ["Lukas Weidenholzer <lukas.weidenholzer@eodc.eu>", "Sean Hoyal <sean.hoyal@eodc.eu>", "Valentina Hutter <valentina.hutter@eodc.eu>", "Gerald Irsiegler <gerald.irsiegler@eodc.eu>"]
@@ -32,6 +32,7 @@ geojson-pydantic = "^0.5.0"
 numpy = "^1.20.3"
 pendulum = "^2.1.2"
 matplotlib = { version = "^3.7.1", optional = true }
+traitlets = "5.9.0"
 
 [tool.poetry.group.dev.dependencies]
 matplotlib = "^3.7.1"


### PR DESCRIPTION
fix: aggregated data being incorrectly calculated because of results_cache

fix: pinned traitlets version (5.9.0) for this release, because the new version (5.10.0) was causing problems when installing the poetry env.