### PR TITLE
Remove Python 3.9, add Python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         include:
           - os: Ubuntu
             image: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - os: Ubuntu
             image: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         include:
           - os: Ubuntu
             image: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.9,<3.14"
 pydantic = "^2.4.0"
-pyproj = "^3.4.0"
+pyproj = "^3.7.2"
 networkx = "^2.8.6"
 shapely = ">=1.8"
 geojson-pydantic = "^1.0.0"
@@ -36,7 +36,7 @@ pendulum = ">=3.0.0"
 matplotlib = { version = "^3.7.1", optional = true }
 traitlets = "<=5.9.0"
 yprov4wfs = ">=0.0.8"
-xarray = ">=2022.11.0,<=2024.3.0"
+xarray = ">=2025.01.1,<=2025.08.01"
 dask = ">=2023.4.0,<2025.2.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
 ]
 
 packages = [
@@ -25,9 +24,9 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.14"
+python = ">=3.9,<3.13"
 pydantic = "^2.4.0"
-pyproj = "^3.7.2"
+pyproj = "^3.4.0"
 networkx = "^2.8.6"
 shapely = ">=1.8"
 geojson-pydantic = "^1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ networkx = "^2.8.6"
 shapely = ">=1.8"
 geojson-pydantic = "^1.0.0"
 numpy = "^1.20.3"
-pendulum = "^2.1.2"
+pendulum = ">=3.0.0"
 matplotlib = { version = "^3.7.1", optional = true }
 traitlets = "<=5.9.0"
 yprov4wfs = ">=0.0.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ pendulum = ">=3.0.0"
 matplotlib = { version = "^3.7.1", optional = true }
 traitlets = "<=5.9.0"
 yprov4wfs = ">=0.0.8"
-xarray = ">=2025.01.1,<=2025.08.01"
+xarray = ">=2022.11.0,<=2025.08.01"
 dask = ">=2023.4.0,<2025.2.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ geojson-pydantic = "^1.0.0"
 numpy = "^1.20.3"
 pendulum = ">=3.0.0"
 matplotlib = { version = "^3.7.1", optional = true }
-traitlets = "<=5.9.0"
+traitlets = "<=5.13.0"
 yprov4wfs = ">=0.0.8"
 xarray = ">=2022.11.0,<=2025.08.01"
 dask = ">=2023.4.0,<2025.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ packages = [
 python = ">=3.10,<3.13"
 pydantic = "^2.4.0"
 pyproj = "^3.4.0"
-networkx = "^2.8.6"
+networkx = ">=3.0.0"
 shapely = ">=1.8"
 geojson-pydantic = "^1.0.0"
 numpy = "^1.20.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">3.9,<3.13"
+python = ">=3.10,<3.13"
 pydantic = "^2.4.0"
 pyproj = "^3.4.0"
 networkx = "^2.8.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 packages = [
@@ -23,7 +25,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.12"
+python = ">=3.9,<3.14"
 pydantic = "^2.4.0"
 pyproj = "^3.4.0"
 networkx = "^2.8.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -24,7 +23,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
+python = ">3.9,<3.13"
 pydantic = "^2.4.0"
 pyproj = "^3.4.0"
 networkx = "^2.8.6"


### PR DESCRIPTION
[Python 3.9 will reach EOL this month](https://devguide.python.org/versions/). In this PR I removed it and added the more recent Python 3.12. Pendulum required to be updated to support Python 3.12 ([PEP 517 incompatibility of pendulum 2.x](https://github.com/python-pendulum/pendulum/issues/862)) and I also extended the compatibility of xarray, so that it's easier to integrate this package in other environments requiring a more recent version. I set networkx to use a more recent version (>=3.0), since it's required by scikit-image.

@ValentinaHutter @rtmiz 