### PR TITLE
add support for python 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: Ubuntu
             image: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 env:
-  POETRY_VERSION: 1.5.1
+  POETRY_VERSION: 2.3.2
 
 jobs:
   tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Set up Python 3.13
+      - name: Set up Python 3.14
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Bootstrap poetry
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_language_version:
     python: python3
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.10.1
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To enable plotting also install the `plot` extra:
 pip install openeo-pg-parser-networkx[plot]
 ```
 
-Currently Python versions 3.10-3.12 are supported.
+Currently Python versions 3.10-3.14 are supported.
 
 ## Basic usage
 (An example notebook of using `openeo-pg-parser-networkx` together with a process implementation source like [`openeo-processes-dask`](https://github.com/Open-EO/openeo-processes-dask) can be found in `openeo-pg-parser-networkx/examples/01_minibackend_demo.ipynb`.)

--- a/openeo_pg_parser_networkx/pg_schema.py
+++ b/openeo_pg_parser_networkx/pg_schema.py
@@ -20,7 +20,6 @@ from geojson_pydantic import (
 )
 from pydantic import (
     BaseModel,
-    Extra,
     Field,
     RootModel,
     StringConstraints,
@@ -57,12 +56,12 @@ __all__ = [
 ]
 
 
-class ResultReference(BaseModel, extra=Extra.forbid):
+class ResultReference(BaseModel, extra="forbid"):
     from_node: str
     node: ProcessNode
 
 
-class ParameterReference(BaseModel, extra=Extra.forbid):
+class ParameterReference(BaseModel, extra="forbid"):
     from_parameter: str
 
 
@@ -105,7 +104,7 @@ class ProcessNode(BaseModel, arbitrary_types_allowed=True):
         return json.dumps(self.dict(), indent=4)
 
 
-class ProcessGraph(BaseModel, extra=Extra.forbid):
+class ProcessGraph(BaseModel, extra="forbid"):
     process_graph: dict[str, ProcessNode]
     uid: UUID = Field(default_factory=uuid4)
 
@@ -115,7 +114,7 @@ class PGEdgeType(str, Enum):
     Callback = "callback"
 
 
-def parse_crs(v) -> pyproj.CRS:
+def parse_crs(v: Optional[Union[str, int]]) -> str:
     if not isinstance(v, int) and (v is None or v.strip() == ""):
         return DEFAULT_CRS
     else:
@@ -128,12 +127,6 @@ def parse_crs(v) -> pyproj.CRS:
             raise e
 
 
-def crs_validator(field: Union[str, int]) -> classmethod:
-    decorator = validator(field, allow_reuse=True, pre=True, always=True)
-    validator_func = decorator(parse_crs)
-    return validator_func
-
-
 class BoundingBox(BaseModel, arbitrary_types_allowed=True):
     west: float
     east: float
@@ -141,10 +134,12 @@ class BoundingBox(BaseModel, arbitrary_types_allowed=True):
     south: float
     base: Optional[float] = None
     height: Optional[float] = None
-    crs: Optional[Union[str, int]] = None
+    crs: Optional[str] = Field(default=DEFAULT_CRS)
 
-    # validators
-    _parse_crs: classmethod = crs_validator('crs')
+    @field_validator("crs", mode="before")
+    @classmethod
+    def validate_crs(cls, v: Optional[Union[str, int]]) -> Optional[str]:
+        return parse_crs(v)
 
     @property
     def polygon(self) -> Polygon:

--- a/openeo_pg_parser_networkx/utils.py
+++ b/openeo_pg_parser_networkx/utils.py
@@ -9,14 +9,14 @@ from openeo_pg_parser_networkx.pg_schema import ParameterReference, ResultRefere
 
 def parse_nested_parameter(parameter: Any):
     try:
-        return ResultReference.parse_obj(parameter)
+        return ResultReference.model_validate(parameter)
     except pydantic.ValidationError:
         pass
     except TypeError:
         pass
 
     try:
-        return ParameterReference.parse_obj(parameter)
+        return ParameterReference.model_validate(parameter)
     except pydantic.ValidationError:
         pass
     except TypeError:
@@ -236,17 +236,17 @@ def _generate_function_from_nodes(nodes: dict):
         if node_type == "array_element":
             value = ast.Subscript(
                 value=ast.Name(id=operand1, ctx=ast.Load()),
-                slice=ast.Index(value=ast.Num(n=int(operand2))),
+                slice=ast.Constant(value=int(operand2)),
                 ctx=ast.Load(),
             )
         elif node_type == "const":
             if isinstance(operand1, list):
                 value = ast.List(
-                    elts=[ast.Num(n=n) for n in operand1],
+                    elts=[ast.Constant(value=n) for n in operand1],
                     ctx=ast.Load(),
                 )
             else:
-                value = ast.Num(n=operand1)
+                value = ast.Constant(value=operand1)
 
         elif node_type == "variable":
             value = ast.Name(id=operand1, ctx=ast.Load())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ geojson-pydantic = "^1.0.0"
 numpy = ">=1.20.3"
 pendulum = ">=3.0.0"
 matplotlib = { version = "^3.7.1", optional = true }
-traitlets = "<=5.13.0"
+traitlets = "<=5.14.4"
 yprov4wfs = ">=0.0.8"
 xarray = ">=2022.11.0"
 dask = ">=2023.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 packages = [
@@ -24,9 +25,9 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.14"
+python = ">=3.10,<3.15"
 pydantic = "^2.4.0"
-pyproj = "^3.4.0"
+pyproj = ">=3.4.0,<4.0"
 networkx = ">=3.0.0"
 geojson-pydantic = "^1.0.0"
 numpy = ">=1.20.3"
@@ -35,7 +36,7 @@ matplotlib = { version = "^3.7.1", optional = true }
 traitlets = "<=5.13.0"
 yprov4wfs = ">=0.0.8"
 xarray = ">=2022.11.0"
-dask = ">=2023.4.0,<2025.2.0"
+dask = ">=2023.4.0"
 
 [tool.poetry.group.dev.dependencies]
 matplotlib = "^3.7.1"


### PR DESCRIPTION
This PR add python 3.14 support and open Dask dependency 

Note: the xarray and Dask have a pretty low usage footprint, only used 👇 

https://github.com/Open-EO/openeo-pg-parser-networkx/blob/158f6d114f03580da37f994839d7dc50d1af5ce9/openeo_pg_parser_networkx/graph.py#L441-L461

the risk of breaking change in both xarray.DataArray and dask.array is pretty low with the usage made in this library 