### PR TITLE
pyproject: update to pytest 9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,12 @@ dask = ">=2023.4.0"
 
 [tool.poetry.group.dev.dependencies]
 matplotlib = "^3.7.1"
-pytest = "^7.1.3"
+pytest = ">=9.0.3"
 ipykernel = "^6.13.0"
 black = "^22.3.0"
 isort = "^5.10.1"
 pre-commit = "^2.20.0"
-pytest-cov = "^4.0.0"
+pytest-cov = ">=7.0.0"
 
 [tool.poetry.extras]
 plot = ["matplotlib"]
@@ -55,6 +55,7 @@ skip-string-normalization = true
 line-length = 90
 
 [tool.pytest.ini_options]
+console_output_style = "times"
 testpaths = [
     "tests",
 ]


### PR DESCRIPTION
Bump pytest and pytest-cov to
more recent versions. This
fixes CVE-2025-71176.

Also enable the "new" output
style "times" that prints
execution times for each
test.