### PR TITLE
Relax geojson-pydantic version restriction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ python = ">=3.10,<3.15"
 pydantic = "^2.4.0"
 pyproj = ">=3.4.0,<4.0"
 networkx = ">=3.0.0"
-geojson-pydantic = "^1.0.0"
+geojson-pydantic = ">=1.0.0"
 numpy = ">=1.20.3"
 pendulum = ">=3.0.0"
 matplotlib = { version = "^3.7.1", optional = true }


### PR DESCRIPTION
This package just imports a couple
of (fairly general) names from
geojson-pydantic, so they are likely
to remain unchanged even across
major versions. Remove the upper
limit so the package manager can
sort out incompatibilities specified
in these dependencies.