### PR TITLE
Fix ProcessRegistry type annotations

### DIFF
--- a/openeo_pg_parser_networkx/graph.py
+++ b/openeo_pg_parser_networkx/graph.py
@@ -32,7 +32,7 @@ from openeo_pg_parser_networkx.pg_schema import (
     ProcessNode,
     ResultReference,
 )
-from openeo_pg_parser_networkx.process_registry import Process
+from openeo_pg_parser_networkx.process_registry import ProcessRegistry
 from openeo_pg_parser_networkx.utils import (
     ProcessGraphUnflattener,
     generate_curve_fit_function,
@@ -325,7 +325,7 @@ class OpenEOProcessGraph:
 
     def to_callable(
         self,
-        process_registry: dict,
+        process_registry: ProcessRegistry,
         results_cache: Optional[dict] = None,
         parameters: Optional[dict] = None,
     ) -> Callable:
@@ -339,7 +339,7 @@ class OpenEOProcessGraph:
     def _map_node_to_callable(
         self,
         node: str,
-        process_registry: dict[str, Process],
+        process_registry: ProcessRegistry,
         results_cache: Optional[dict] = None,
         named_parameters: Optional[dict] = None,
     ) -> Callable:

--- a/openeo_pg_parser_networkx/process_registry.py
+++ b/openeo_pg_parser_networkx/process_registry.py
@@ -23,8 +23,8 @@ class ProcessRegistry(MutableMapping):
 
     def __init__(self, wrap_funcs: Optional[list] = None, *args, **kwargs):
         """wrap_funcs: list of decorators to apply to all registered processes."""
-        self.store = dict()  # type: dict[str, dict[str, Process]]
-        self.aliases = dict()  # type: dict[str, dict[str, str]]
+        self.store: dict[str, dict[str, Process]] = dict()
+        self.aliases: dict[str, dict[str, str]] = dict()
 
         if wrap_funcs is None:
             wrap_funcs = []


### PR DESCRIPTION
The examples in the README pass
in a ProcessRegistry to to_callable,
so annotate the argument with that
type, and convert the type comments
into type hints in the ProcessRegistry
constructor.